### PR TITLE
GraphQL Resolver for the mutation `addCollection`

### DIFF
--- a/server/deploy/scripts/api.ts
+++ b/server/deploy/scripts/api.ts
@@ -8,7 +8,6 @@ import { ElasticSearchService } from '../../src/infrastructure/ElasticSearchServ
 import { SearchService } from '../../src/infrastructure/SearchService';
 
 const searcher : SearchService = new ElasticSearchService();
-
 const userModel = require("../infrastructure/user");
 const bodyParser = require('body-parser'); 
 

--- a/server/src/infrastructure/SearchResult.ts
+++ b/server/src/infrastructure/SearchResult.ts
@@ -30,6 +30,21 @@ export class StoredBankNoteCollection {
     }
 }
 
+export type UpdateCollectionInput = {
+    name: string,
+    description: string
+}
+
+export type BankNoteInputCollectionItem = {   
+    id: string
+}
+
+export type AddBankNoteToCollection = {
+    collectionId: string,
+    collectorId: string,
+    bankNoteCollectionItem: BankNoteCollectionItem
+}
+
 export class CollectionResult {
     constructor(public collections: BankNoteCollection[]) {}
 }
@@ -40,17 +55,9 @@ export type NewCollectionInput = {
     collectorId: string
 }
 
-export type UpdateCollectionInput = {
+export type CollectionCreatedResult = {
+    collectionId: string, //TODO: inconsistent with the above in the API, raised #127 to fix
     name: string,
-    description: string
-}
-
-export type BankNoteInputCollectionItem = {   
-    catalogCode: string
-}
-
-export type AddBankNoteToCollection = {
-    collectionId: string,
-    collectorId: string,
-    bankNoteCollectionItem: BankNoteCollectionItem
+    description: string,
+    collectorId: string
 }

--- a/server/src/infrastructure/collections/CollectionsRestDatasource.ts
+++ b/server/src/infrastructure/collections/CollectionsRestDatasource.ts
@@ -1,5 +1,13 @@
 import { RESTDataSource } from 'apollo-datasource-rest';
 import { CollectionApiResult } from './types';
+import { NewCollectionInput } from '../SearchResult';
+import { CollectionCreatedResult } from '../SearchResult';
+import {
+  Request
+} from 'apollo-server-env';
+import {
+  ApolloError
+} from 'apollo-server-errors';
 
 export class CollectionsRestDatasource extends RESTDataSource {
   
@@ -15,4 +23,18 @@ export class CollectionsRestDatasource extends RESTDataSource {
   async getItemsForCollection(collectionId: string): Promise<CollectionApiResult> {
     return this.get(`collections/${collectionId}`);
   }
+
+  async createCollection(collection: NewCollectionInput): Promise<CollectionCreatedResult> {
+    return this.post(`collections`, collection);
+  }
+
+  //TODO: workaround for now, the server should return this already. Created bug #130 for this
+  protected didEncounterError(error: ApolloError, _request: Request) {
+    let message = error.extensions.response.body.message;
+    console.log("Error from API", message);
+    error.extensions.code = "BAD_REQUEST";
+    error.extensions.response.status = 400;
+    throw error;
+  }
+
 };

--- a/server/src/resolverMap.ts
+++ b/server/src/resolverMap.ts
@@ -4,7 +4,7 @@
 import { IResolvers, addSchemaLevelResolveFunction } from 'graphql-tools';
 import { SearchService } from './infrastructure/SearchService';
 import { ElasticSearchService } from './infrastructure/ElasticSearchService';
-import { SearchResult } from './infrastructure/SearchResult';
+import { SearchResult, CollectionResult } from './infrastructure/SearchResult';
 import { BankNoteCollection } from './infrastructure/SearchResult';
 import { NewCollectionInput } from './infrastructure/SearchResult';
 import { AddBankNoteToCollection } from './infrastructure/SearchResult';
@@ -37,11 +37,14 @@ const resolverMap: IResolvers = {
         }
     },
     Mutation: {
-        async addCollection(_: void, args: { collection: NewCollectionInput }): Promise<BankNoteCollection | null> {
-            console.log(`About to create collection for ${args.collection.collectorId}: ${args.collection.name}, ${args.collection.description}`)
-            let bankNoteCollection = fakeData.addCollection(args.collection);
-            return Promise.resolve(bankNoteCollection);
+        
+        async addCollection(_: void, args: { collection: NewCollectionInput }, { dataSources }): Promise<BankNoteCollection | null> {
+            let { collection } = args
+            console.log(`About to create collection for ${collection.collectorId}: ${collection.name}, ${collection.description}`);
+            let { collectionId, name, description, collectorId } = await dataSources.collectionsAPI.createCollection(collection);
+            return new BankNoteCollection(collectionId, name, description, collectorId, []);
         },
+
         async addBankNoteToCollection(_: void, args: { data: AddBankNoteToCollection }): Promise<BankNoteCollection> {
             console.log(`Adding banknote to collection: ${args.data.collectionId}`)
             let bankNoteCollection: BankNoteCollection = fakeData.addBankNoteToCollection(args.data.collectionId, args.data.bankNoteCollectionItem);


### PR DESCRIPTION
This is the mutation that allows creation of a collection using the REST API `collections-api`.

Right now there is a bug in the API that returns 500 error instead of 400 when the name is repeated. The #130 issue has been created to address this.